### PR TITLE
Fixed crash when writing windows

### DIFF
--- a/windows/ble_peripheral_plugin.cpp
+++ b/windows/ble_peripheral_plugin.cpp
@@ -9,7 +9,6 @@
 #include <thread>
 #include <regex>
 #include "Utils.h"
-
 #include "BlePeripheral.g.h"
 
 namespace ble_peripheral
@@ -571,6 +570,7 @@ namespace ble_peripheral
 
   winrt::fire_and_forget BlePeripheralPlugin::WriteRequestedAsync(GattLocalCharacteristic const &localChar, GattWriteRequestedEventArgs args)
   {
+    std::string characteristicId = to_uuidstr(localChar.Uuid());
     auto deferral = args.GetDeferral();
     GattWriteRequest request = co_await args.GetRequestAsync();
     if (request == nullptr)
@@ -581,10 +581,8 @@ namespace ble_peripheral
     }
 
     std::string deviceId = ParseBluetoothClientId(args.Session().DeviceId().Id());
-
-    uiThreadHandler_.Post([localChar, request, deferral, deviceId]
+    uiThreadHandler_.Post([localChar, request, deferral, deviceId, characteristicId]
                           {
-                            auto characteristicId = guid_to_uuid(localChar.Uuid());
                             int64_t offset = request.Offset();
                             auto bytevc = to_bytevc(request.Value());
                             std::vector<uint8_t> *value_arg = &bytevc;


### PR DESCRIPTION
# Please merge now. This is a serious issue.
You cannot get the uuid inside a lambda expression.
Therefore, the uuid was obtained using the same method as Read.
Looking at the code, there are many parts that need to be standardized, but what is required now is that the code should be able to function normally as indicated by the OSS.
Please merge as soon as possible.