### PR TITLE
Add optional requireBonding parameter and localName validation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'com.rohit.ble_peripheral'
 
-    compileSdk 34
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/kotlin/com/rohit/ble_peripheral/BlePeripheral.g.kt
+++ b/android/src/main/kotlin/com/rohit/ble_peripheral/BlePeripheral.g.kt
@@ -303,7 +303,7 @@ interface BlePeripheralChannel {
   fun removeService(serviceId: String)
   fun clearServices()
   fun getServices(): List<String>
-  fun startAdvertising(services: List<String>, localName: String?, timeout: Long?, manufacturerData: ManufacturerData?, addManufacturerDataInScanResponse: Boolean)
+  fun startAdvertising(services: List<String>, localName: String?, timeout: Long?, manufacturerData: ManufacturerData?, addManufacturerDataInScanResponse: Boolean, requireBonding: Boolean)
   fun updateCharacteristic(characteristicId: String, value: ByteArray, deviceId: String?)
 
   companion object {
@@ -469,8 +469,9 @@ interface BlePeripheralChannel {
             val timeoutArg = args[2] as Long?
             val manufacturerDataArg = args[3] as ManufacturerData?
             val addManufacturerDataInScanResponseArg = args[4] as Boolean
+            val requireBondingArg = args[5] as Boolean
             val wrapped: List<Any?> = try {
-              api.startAdvertising(servicesArg, localNameArg, timeoutArg, manufacturerDataArg, addManufacturerDataInScanResponseArg)
+              api.startAdvertising(servicesArg, localNameArg, timeoutArg, manufacturerDataArg, addManufacturerDataInScanResponseArg, requireBondingArg)
               listOf(null)
             } catch (exception: Throwable) {
               wrapError(exception)

--- a/android/src/main/kotlin/com/rohit/ble_peripheral/BlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/com/rohit/ble_peripheral/BlePeripheralPlugin.kt
@@ -126,7 +126,7 @@ class BlePeripheralPlugin : FlutterPlugin, BlePeripheralChannel, ActivityAware {
         }
 
         handler?.post { // set up advertising setting
-            localName?.let { bluetoothManager?.adapter?.name = it }
+            bluetoothManager?.adapter?.name = localName ?: android.os.Build.MODEL
             val advertiseSettings = AdvertiseSettings.Builder()
                 .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
                 .setConnectable(true)

--- a/android/src/main/kotlin/com/rohit/ble_peripheral/BlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/com/rohit/ble_peripheral/BlePeripheralPlugin.kt
@@ -50,6 +50,7 @@ class BlePeripheralPlugin : FlutterPlugin, BlePeripheralChannel, ActivityAware {
     private val emptyBytes = byteArrayOf()
     private val listOfDevicesWaitingForBond = mutableListOf<String>()
     private var isAdvertising: Boolean? = null
+    private var requireBonding: Boolean = true
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         BlePeripheralChannel.setUp(flutterPluginBinding.binaryMessenger, this)
@@ -116,7 +117,9 @@ class BlePeripheralPlugin : FlutterPlugin, BlePeripheralChannel, ActivityAware {
         timeout: Long?,
         manufacturerData: ManufacturerData?,
         addManufacturerDataInScanResponse: Boolean,
+        requireBonding: Boolean,
     ) {
+        this.requireBonding = requireBonding
         if (!isBluetoothEnabled()) {
             enableBluetooth()
             throw Exception("Bluetooth is not enabled")
@@ -290,13 +293,13 @@ class BlePeripheralPlugin : FlutterPlugin, BlePeripheralChannel, ActivityAware {
                 super.onConnectionStateChange(device, status, newState)
                 when (newState) {
                     BluetoothProfile.STATE_CONNECTED -> {
-                        if (device.bondState == BluetoothDevice.BOND_NONE) {
+                        if (requireBonding && device.bondState == BluetoothDevice.BOND_NONE) {
                             // Wait for bonding
                             listOfDevicesWaitingForBond.add(device.address)
                             device.createBond()
-                        } else if (device.bondState == BluetoothDevice.BOND_BONDED) {
+                        } else if (!requireBonding || device.bondState == BluetoothDevice.BOND_BONDED) {
                             handler?.post {
-                                gattServer?.connect(device, true)
+                                gattServer?.connect(device, requireBonding)
                             }
                             synchronized(bluetoothDevicesMap) {
                                 bluetoothDevicesMap.put(

--- a/lib/src/ble_peripheral.dart
+++ b/lib/src/ble_peripheral.dart
@@ -73,6 +73,7 @@ class BlePeripheral {
     int? timeout,
     ManufacturerData? manufacturerData,
     bool addManufacturerDataInScanResponse = false,
+    bool requireBonding = true,
   }) {
     return _platform.startAdvertising(
       services: services,
@@ -80,6 +81,7 @@ class BlePeripheral {
       timeout: timeout,
       manufacturerData: manufacturerData,
       addManufacturerDataInScanResponse: addManufacturerDataInScanResponse,
+      requireBonding: requireBonding,
     );
   }
 

--- a/lib/src/ble_peripheral.dart
+++ b/lib/src/ble_peripheral.dart
@@ -67,6 +67,11 @@ class BlePeripheral {
 
   /// Start advertising with the given services and local name
   /// make sure to add services before calling this method
+  ///
+  /// [localName] must not exceed 8 characters. Longer names cause
+  /// `ADVERTISE_FAILED_DATA_TOO_LARGE` on Android when combined with a
+  /// 128-bit service UUID in the same 31-byte advertising packet.
+  /// Note: [localName] is ignored on iOS.
   static Future<void> startAdvertising({
     required List<String> services,
     String? localName,
@@ -75,6 +80,12 @@ class BlePeripheral {
     bool addManufacturerDataInScanResponse = false,
     bool requireBonding = true,
   }) {
+    if (localName != null && localName.length > 8) {
+      throw ArgumentError(
+        'localName "$localName" is ${localName.length} characters. '
+        'Maximum allowed is 8 to avoid ADVERTISE_FAILED_DATA_TOO_LARGE.',
+      );
+    }
     return _platform.startAdvertising(
       services: services,
       localName: localName,

--- a/lib/src/ble_peripheral_interface.dart
+++ b/lib/src/ble_peripheral_interface.dart
@@ -37,6 +37,7 @@ abstract class BlePeripheralInterface {
     int? timeout,
     ManufacturerData? manufacturerData,
     bool addManufacturerDataInScanResponse = false,
+    bool requireBonding = true,
   });
 
   Future<void> stopAdvertising();

--- a/lib/src/generated/ble_peripheral.g.dart
+++ b/lib/src/generated/ble_peripheral.g.dart
@@ -509,7 +509,7 @@ class BlePeripheralChannel {
     }
   }
 
-  Future<void> startAdvertising(List<String> services, String? localName, int? timeout, ManufacturerData? manufacturerData, bool addManufacturerDataInScanResponse) async {
+  Future<void> startAdvertising(List<String> services, String? localName, int? timeout, ManufacturerData? manufacturerData, bool addManufacturerDataInScanResponse, bool requireBonding) async {
     final String pigeonVar_channelName = 'dev.flutter.pigeon.ble_peripheral.BlePeripheralChannel.startAdvertising$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
@@ -517,7 +517,7 @@ class BlePeripheralChannel {
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_channel.send(<Object?>[services, localName, timeout, manufacturerData, addManufacturerDataInScanResponse]) as List<Object?>?;
+        await pigeonVar_channel.send(<Object?>[services, localName, timeout, manufacturerData, addManufacturerDataInScanResponse, requireBonding]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {

--- a/lib/src/pigeon/ble_peripheral_pigeon.dart
+++ b/lib/src/pigeon/ble_peripheral_pigeon.dart
@@ -94,6 +94,7 @@ class BlePeripheralPigeon extends BlePeripheralInterface {
     int? timeout,
     ManufacturerData? manufacturerData,
     bool addManufacturerDataInScanResponse = false,
+    bool requireBonding = true,
   }) {
     if (defaultTargetPlatform == TargetPlatform.windows &&
         manufacturerData == null) {
@@ -104,7 +105,7 @@ class BlePeripheralPigeon extends BlePeripheralInterface {
       );
     }
     return _channel.startAdvertising(services, localName, timeout,
-        manufacturerData, addManufacturerDataInScanResponse);
+        manufacturerData, addManufacturerDataInScanResponse, requireBonding);
   }
 
   /// Stop advertising

--- a/pigeons/ble.dart
+++ b/pigeons/ble.dart
@@ -99,6 +99,7 @@ abstract class BlePeripheralChannel {
     int? timeout,
     ManufacturerData? manufacturerData,
     bool addManufacturerDataInScanResponse,
+    bool requireBonding,
   );
 
   void updateCharacteristic(


### PR DESCRIPTION
## Changes

### 1. Add optional `requireBonding` parameter to [startAdvertising](cci:1://file:///Users/yarith/Documents/ble_peripheral/lib/src/ble_peripheral_interface.dart:33:2-40:4)

The original plugin always initiates bonding for `BOND_NONE` devices, 
which triggers a pairing dialog on the remote device. This is not always 
desirable — for characteristics using `PERMISSION_WRITE` (not encrypted), 
no bond is required.

**New parameter:**
```dart
await BlePeripheral.startAdvertising(
  services: [...],
  requireBonding: true,  // default — original behaviour preserved
);

// Opt out of bonding to connect immediately without pairing dialog:
await BlePeripheral.startAdvertising(
  services: [...],
  requireBonding: false,
);
```

2. Fix stale device name in scan response
Previously, if localName was not provided, the BLE adapter would keep a stale name from a previous advertising run. The adapter name is now reset to Build.MODEL when no localName is given.

3. Validate localName length at Dart level
Names longer than 8 characters cause ADVERTISE_FAILED_DATA_TOO_LARGE on Android when combined with a 128-bit service UUID in the 31-byte advertising packet. An ArgumentError is now thrown early with a descriptive message instead of a cryptic platform error.